### PR TITLE
delete flask

### DIFF
--- a/learning-backEnd.txt
+++ b/learning-backEnd.txt
@@ -9,4 +9,3 @@ BackEnd :
     * Framework
       + Laravel
       + viu
-  - learning flask


### PR DESCRIPTION
There are 2 reasons, why I removed the flask framework  from the list backend. Number 1, cause the django framework is more powerful and stable when u create the public website ,that's why u don't need to learn flask framework at all, Number 2, your times would be wasted when u learn flask framework and you have learned about django framework. That's it, the reason for deleting your flask list in your list backend. Thanks you.